### PR TITLE
Correct pointer argument * positioning.

### DIFF
--- a/STYLE.c
+++ b/STYLE.c
@@ -26,7 +26,7 @@
  * @param string_array String arrays, which are separated.
  * @returns Stuff.
  */
-int function(int argument, void * pointer, char * string_array[]) {
+int function(int argument, void *pointer, char * string_array[]) {
 	/* Inline comments should use the classic C-style*/
 	if (condition) {
 		/*


### PR DESCRIPTION
The comments specify that the \* of a pointer should be "immediately"
before the identifier, but this was not reflected in the parameter
list.
