### PR TITLE
Correct newlib autotools files for new automake

### DIFF
--- a/toolchain/install.sh
+++ b/toolchain/install.sh
@@ -31,9 +31,14 @@ pushd build
         rm -r newlib
         mkdir newlib
     fi
+    pushd $DIR/tarballs/newlib-1.19.0
+        [ -z "$(automake --version | grep -e '1.13.' -e '1.14.')" ] && return
+        find -type f -exec sed 's|--cygnus||g;s|cygnus||g' -i {} + || bail
+    popd
     pushd $DIR/tarballs/newlib-1.19.0/newlib/libc/sys
         autoconf || bail
         pushd toaru
+            touch INSTALL NEWS README AUTHORS ChangeLog COPYING || bail
             autoreconf || bail
             yasm -f elf -o crt0.o crt0.s || bail
             yasm -f elf -o crti.o crti.s || bail


### PR DESCRIPTION
On automake>=1.13.x --cygnus has been removed and
causes failures during autoreconf. In addition
create various files (NEWS, README, etc.) to
prevent errors, again, during autoreconf.
