### PR TITLE
Update terminal-vga.c

### DIFF
--- a/userspace/gui/terminal/terminal-vga.c
+++ b/userspace/gui/terminal/terminal-vga.c
@@ -60,7 +60,7 @@ void term_redraw_cursor();
 /* Cursor bink timer */
 static unsigned int timer_tick = 0;
 
-void term_clear();
+void term_clear(int);
 
 void dump_buffer();
 
@@ -270,7 +270,7 @@ void term_redraw_all() {
 
 void term_scroll(int how_much) {
 	if (how_much >= term_height || -how_much >= term_height) {
-		term_clear();
+		term_clear(2);
 		return;
 	}
 	if (how_much == 0) {


### PR DESCRIPTION
term_clear() needs an argument. Hope 2 is the correct argument in term_scroll.
