### PR TITLE
Added self entry to procfs

### DIFF
--- a/modules/procfs.c
+++ b/modules/procfs.c
@@ -280,6 +280,7 @@ static struct procfs_entry std_entries[] = {
 	{-4, "cmdline",  cmdline_func},
 	{-5, "version",  version_func},
 	{-6, "compiler", compiler_func},
+	{-7, "self",     NULL},          /* Specially handled in finddir_procfs_root */
 };
 
 static struct dirent * readdir_procfs_root(fs_node_t *node, uint32_t index) {
@@ -347,6 +348,10 @@ static fs_node_t * finddir_procfs_root(fs_node_t * node, char * name) {
 			return NULL;
 		}
 		fs_node_t * out = procfs_procdir_create(pid);
+		return out;
+	}
+	if (!strcmp(name, "self")) {
+		fs_node_t * out = procfs_procdir_create(current_process->id);
 		return out;
 	}
 


### PR DESCRIPTION
This provides an alias to the process directory for the current process. Linux has such an entry in its procfs.

Hi klange, I just saw this project and thought it looked pretty fun! This is a pretty trivial change, but it seemed an easy place to start poking my way around the code. 