### PR TITLE
compositor: get rid of a leak in window_actually_close

### DIFF
--- a/userspace/gui/compositor/compositor.c
+++ b/userspace/gui/compositor/compositor.c
@@ -1242,7 +1242,6 @@ static void window_actually_close(yutani_globals_t * yg, yutani_server_window_t 
 	}
 
 	/* Notify subscribers that there are changes to windows */
-	yutani_msg_t * response = yutani_msg_build_notify();
 	notify_subscribers(yg);
 }
 


### PR DESCRIPTION
The function call allocates on the heap, so this would cause a leak.