### PR TITLE
Added fchdir system call

### DIFF
--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -779,7 +779,15 @@ fs_node_t *get_mount_point(char * path, unsigned int path_depth, char **outpath,
 	return last;
 }
 
-
+static void fs_node_fill_path(fs_node_t * node, char * filename, char * relative_to) {
+	char * unfettered_path = canonicalize_path(relative_to, filename);
+	if (strlen(unfettered_path) > sizeof(node->path) - 1) {
+		debug_print(WARNING, "Path %s is too long to fill fs_node path value", unfettered_path);
+	} else {
+		strcpy(node->path, unfettered_path);
+	}
+	free(unfettered_path);
+}
 
 fs_node_t *kopen_recur(char *filename, uint32_t flags, uint32_t symlink_depth, char *relative_to) {
 	/* Simple sanity checks that we actually have a file system */
@@ -802,6 +810,7 @@ fs_node_t *kopen_recur(char *filename, uint32_t flags, uint32_t symlink_depth, c
 		free(path);
 
 		open_fs(root_clone, flags);
+		fs_node_fill_path(root_clone, filename, relative_to);
 
 		/* And return the clone */
 		return root_clone;
@@ -842,6 +851,7 @@ fs_node_t *kopen_recur(char *filename, uint32_t flags, uint32_t symlink_depth, c
 	if (path_offset >= path+path_len) {
 		free(path);
 		open_fs(node_ptr, flags);
+		fs_node_fill_path(node_ptr, filename, relative_to);
 		return node_ptr;
 	}
 	fs_node_t *node_next = NULL;
@@ -925,7 +935,7 @@ fs_node_t *kopen_recur(char *filename, uint32_t flags, uint32_t symlink_depth, c
 		if (depth == path_depth - 1) {
 			/* We found the file and are done, open the node */
 			open_fs(node_ptr, flags);
-			free((void *)path);
+			fs_node_fill_path(node_ptr, filename, relative_to);
 			return node_ptr;
 		}
 		/* We are still searching... */

--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -165,6 +165,9 @@ void close_fs(fs_node_t *node) {
 		if (node->close) {
 			node->close(node);
 		}
+		if (node->path) {
+			free(node->path);
+		}
 
 		free(node);
 	}
@@ -780,13 +783,7 @@ fs_node_t *get_mount_point(char * path, unsigned int path_depth, char **outpath,
 }
 
 static void fs_node_fill_path(fs_node_t * node, char * filename, char * relative_to) {
-	char * unfettered_path = canonicalize_path(relative_to, filename);
-	if (strlen(unfettered_path) > sizeof(node->path) - 1) {
-		debug_print(WARNING, "Path %s is too long to fill fs_node path value", unfettered_path);
-	} else {
-		strcpy(node->path, unfettered_path);
-	}
-	free(unfettered_path);
+	node->path = canonicalize_path(relative_to, filename);
 }
 
 fs_node_t *kopen_recur(char *filename, uint32_t flags, uint32_t symlink_depth, char *relative_to) {

--- a/kernel/include/fs.h
+++ b/kernel/include/fs.h
@@ -54,6 +54,7 @@ typedef int (*readlink_type_t) (struct fs_node *, char * buf, size_t size);
 
 typedef struct fs_node {
 	char name[256];         /* The filename. */
+	char path[4096];        /* The path the node was opened at. */
 	void * device;          /* Device object (optional) */
 	uint32_t mask;          /* The permissions mask. */
 	uint32_t uid;           /* The owning user. */

--- a/kernel/include/fs.h
+++ b/kernel/include/fs.h
@@ -54,7 +54,6 @@ typedef int (*readlink_type_t) (struct fs_node *, char * buf, size_t size);
 
 typedef struct fs_node {
 	char name[256];         /* The filename. */
-	char * path;            /* The path the node was opened at. */
 	void * device;          /* Device object (optional) */
 	uint32_t mask;          /* The permissions mask. */
 	uint32_t uid;           /* The owning user. */
@@ -90,6 +89,7 @@ typedef struct fs_node {
 	uint32_t offset;       /* Offset for read operations XXX move this to new "file descriptor" entry */
 	int32_t refcount;
 	uint32_t nlink;
+	char * path;            /* The path the node was opened at. */
 } fs_node_t;
 
 struct dirent {

--- a/kernel/include/fs.h
+++ b/kernel/include/fs.h
@@ -54,7 +54,7 @@ typedef int (*readlink_type_t) (struct fs_node *, char * buf, size_t size);
 
 typedef struct fs_node {
 	char name[256];         /* The filename. */
-	char path[4096];        /* The path the node was opened at. */
+	char * path;            /* The path the node was opened at. */
 	void * device;          /* Device object (optional) */
 	uint32_t mask;          /* The permissions mask. */
 	uint32_t uid;           /* The owning user. */

--- a/toolchain/patches/newlib-1.19.0.patch
+++ b/toolchain/patches/newlib-1.19.0.patch
@@ -1,6 +1,6 @@
-diff -rupN _source/newlib-1.19.0/config.sub newlib-1.19.0/config.sub
---- _source/newlib-1.19.0/config.sub	2010-06-01 12:53:40.000000000 -0500
-+++ newlib-1.19.0/config.sub	2011-04-24 20:37:12.000000000 -0500
+diff -rupN _source/config.sub newlib-1.19.0/config.sub
+--- _source/config.sub	2010-06-01 17:53:40.000000000 +0000
++++ newlib-1.19.0/config.sub	2015-07-01 07:12:59.000000000 +0000
 @@ -1298,6 +1298,7 @@ case $os in
  	      | -sym* | -kopensolaris* \
  	      | -amigaos* | -amigados* | -msdos* | -newsos* | -unicos* | -aof* \
@@ -9,9 +9,9 @@ diff -rupN _source/newlib-1.19.0/config.sub newlib-1.19.0/config.sub
  	      | -nindy* | -vxsim* | -vxworks* | -ebmon* | -hms* | -mvs* \
  	      | -clix* | -riscos* | -uniplus* | -iris* | -rtu* | -xenix* \
  	      | -hiux* | -386bsd* | -knetbsd* | -mirbsd* | -netbsd* \
-diff -rupN _source/newlib-1.19.0/newlib/configure.host newlib-1.19.0/newlib/configure.host
---- _source/newlib-1.19.0/newlib/configure.host	2010-12-02 13:30:46.000000000 -0600
-+++ newlib-1.19.0/newlib/configure.host	2011-04-24 20:38:10.000000000 -0500
+diff -rupN _source/newlib/configure.host newlib-1.19.0/newlib/configure.host
+--- _source/newlib/configure.host	2010-12-02 19:30:46.000000000 +0000
++++ newlib-1.19.0/newlib/configure.host	2015-07-01 07:12:59.000000000 +0000
 @@ -418,6 +418,9 @@ case "${host}" in
    h8500-*-elf*)
  	sys_dir=h8500hms
@@ -20,8 +20,8 @@ diff -rupN _source/newlib-1.19.0/newlib/configure.host newlib-1.19.0/newlib/conf
 +	sys_dir=toaru
 +	;;
    i[34567]86-*-rdos*)
-  sys_dir=rdos
-  newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
+ 	sys_dir=rdos
+ 	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
 @@ -543,6 +546,9 @@ esac
  # THIS TABLE IS ALPHA SORTED.  KEEP IT THAT WAY.
  
@@ -30,11 +30,11 @@ diff -rupN _source/newlib-1.19.0/newlib/configure.host newlib-1.19.0/newlib/conf
 +	newlib_cflags="${newlib_cflags} -fPIC -DSIGNAL_PROVIDED -DMISSING_SYSCALL_NAMES -DMALLOC_PROVIDED"
 +	;;
    *-*-cygwin*)
-  test -z "$cygwin_srcdir" && cygwin_srcdir=`cd ${srcdir}/../winsup/cygwin; pwd`
-  export cygwin_srcdir
-diff -rupN _source/newlib-1.19.0/newlib/libc/include/sys/stat.h newlib-1.19.0/newlib/libc/include/sys/stat.h
---- _source/newlib-1.19.0/newlib/libc/include/sys/stat.h	2010-08-06 13:26:21.000000000 -0500
-+++ newlib-1.19.0/newlib/libc/include/sys/stat.h	2012-04-23 16:00:11.000000000 -0500
+ 	test -z "$cygwin_srcdir" && cygwin_srcdir=`cd ${srcdir}/../winsup/cygwin; pwd`
+ 	export cygwin_srcdir
+diff -rupN _source/newlib/libc/include/sys/stat.h newlib-1.19.0/newlib/libc/include/sys/stat.h
+--- _source/newlib/libc/include/sys/stat.h	2010-08-06 18:26:21.000000000 +0000
++++ newlib-1.19.0/newlib/libc/include/sys/stat.h	2015-07-01 07:12:59.000000000 +0000
 @@ -150,8 +150,8 @@ int	_EXFUN(mkfifo,( const char *__path,
  int	_EXFUN(stat,( const char *__path, struct stat *__sbuf ));
  mode_t	_EXFUN(umask,( mode_t __mask ));
@@ -45,9 +45,22 @@ diff -rupN _source/newlib-1.19.0/newlib/libc/include/sys/stat.h newlib-1.19.0/ne
  int	_EXFUN(mknod,( const char *__path, mode_t __mode, dev_t __dev ));
  #endif
  
-diff -rupN _source/newlib-1.19.0/newlib/libc/include/sys/utime.h newlib-1.19.0/newlib/libc/include/sys/utime.h
---- _source/newlib-1.19.0/newlib/libc/include/sys/utime.h	2000-02-17 13:39:46.000000000 -0600
-+++ newlib-1.19.0/newlib/libc/include/sys/utime.h	2012-04-23 16:01:17.000000000 -0500
+diff -rupN _source/newlib/libc/include/sys/unistd.h newlib-1.19.0/newlib/libc/include/sys/unistd.h
+--- _source/newlib/libc/include/sys/unistd.h	2010-10-08 15:28:49.000000000 +0000
++++ newlib-1.19.0/newlib/libc/include/sys/unistd.h	2015-07-01 07:16:16.000000000 +0000
+@@ -53,9 +53,7 @@ int     _EXFUN(execvp, (const char *__fi
+ int     _EXFUN(execvpe, (const char *__file, char * const __argv[], char * const __envp[] ));
+ int	_EXFUN(faccessat, (int __dirfd, const char *__path, int __mode, int __flags));
+ #endif
+-#if defined(__CYGWIN__) || defined(__rtems__) || defined(__SPU__)
+ int     _EXFUN(fchdir, (int __fildes));
+-#endif
+ int     _EXFUN(fchmod, (int __fildes, mode_t __mode ));
+ #if !defined(__INSIDE_CYGWIN__)
+ int     _EXFUN(fchown, (int __fildes, uid_t __owner, gid_t __group ));
+diff -rupN _source/newlib/libc/include/sys/utime.h newlib-1.19.0/newlib/libc/include/sys/utime.h
+--- _source/newlib/libc/include/sys/utime.h	2000-02-17 19:39:46.000000000 +0000
++++ newlib-1.19.0/newlib/libc/include/sys/utime.h	2015-07-01 07:12:59.000000000 +0000
 @@ -15,6 +15,8 @@ struct utimbuf
    time_t modtime; 
  };
@@ -57,9 +70,9 @@ diff -rupN _source/newlib-1.19.0/newlib/libc/include/sys/utime.h newlib-1.19.0/n
  #ifdef __cplusplus
  };
  #endif
-diff -rupN _source/newlib-1.19.0/newlib/libc/stdio/fseek.c newlib-1.19.0/newlib/libc/stdio/fseek.c
---- _source/newlib-1.19.0/newlib/libc/stdio/fseek.c	2009-12-17 13:43:43.000000000 -0600
-+++ newlib-1.19.0/newlib/libc/stdio/fseek.c	2011-04-29 19:33:10.000000000 -0500
+diff -rupN _source/newlib/libc/stdio/fseek.c newlib-1.19.0/newlib/libc/stdio/fseek.c
+--- _source/newlib/libc/stdio/fseek.c	2009-12-17 19:43:43.000000000 +0000
++++ newlib-1.19.0/newlib/libc/stdio/fseek.c	2015-07-01 07:12:59.000000000 +0000
 @@ -160,210 +160,6 @@ _DEFUN(_fseek_r, (ptr, fp, offset, whenc
        return EOF;
      }
@@ -271,9 +284,9 @@ diff -rupN _source/newlib-1.19.0/newlib/libc/stdio/fseek.c newlib-1.19.0/newlib/
  dumb:
    if (_fflush_r (ptr, fp)
        || seekfn (ptr, fp->_cookie, offset, whence) == POS_ERR)
-diff -rupN _source/newlib-1.19.0/newlib/libc/stdlib/mallocr.c newlib-1.19.0/newlib/libc/stdlib/mallocr.c
---- _source/newlib-1.19.0/newlib/libc/stdlib/mallocr.c	2010-05-31 14:15:41.000000000 -0500
-+++ newlib-1.19.0/newlib/libc/stdlib/mallocr.c	2011-04-30 21:28:46.000000000 -0500
+diff -rupN _source/newlib/libc/stdlib/mallocr.c newlib-1.19.0/newlib/libc/stdlib/mallocr.c
+--- _source/newlib/libc/stdlib/mallocr.c	2010-05-31 19:15:41.000000000 +0000
++++ newlib-1.19.0/newlib/libc/stdlib/mallocr.c	2015-07-01 07:12:59.000000000 +0000
 @@ -609,8 +609,11 @@ do {
    operating system immediately after a free().
  */
@@ -287,9 +300,9 @@ diff -rupN _source/newlib-1.19.0/newlib/libc/stdlib/mallocr.c newlib-1.19.0/newl
  #endif
  
  /*
-diff -rupN _source/newlib-1.19.0/newlib/libc/sys/configure newlib-1.19.0/newlib/libc/sys/configure
---- _source/newlib-1.19.0/newlib/libc/sys/configure	2010-12-16 15:59:03.000000000 -0600
-+++ newlib-1.19.0/newlib/libc/sys/configure	2011-04-24 20:39:58.000000000 -0500
+diff -rupN _source/newlib/libc/sys/configure newlib-1.19.0/newlib/libc/sys/configure
+--- _source/newlib/libc/sys/configure	2010-12-16 21:59:03.000000000 +0000
++++ newlib-1.19.0/newlib/libc/sys/configure	2015-07-01 07:12:59.000000000 +0000
 @@ -798,6 +798,7 @@ sysvi386
  sysvnecv70
  tic80
@@ -298,7 +311,7 @@ diff -rupN _source/newlib-1.19.0/newlib/libc/sys/configure newlib-1.19.0/newlib/
  z8ksim'
  
  # Initialize some variables set by options.
-@@ -11820,6 +11827,8 @@ subdirs="$subdirs a29khif"
+@@ -11820,6 +11821,8 @@ subdirs="$subdirs a29khif"
   ;;
  	w65) subdirs="$subdirs w65"
   ;;
@@ -307,9 +320,9 @@ diff -rupN _source/newlib-1.19.0/newlib/libc/sys/configure newlib-1.19.0/newlib/
  	z8ksim) subdirs="$subdirs z8ksim"
   ;;
    esac;
-diff -rupN _source/newlib-1.19.0/newlib/libc/sys/configure.in newlib-1.19.0/newlib/libc/sys/configure.in
---- _source/newlib-1.19.0/newlib/libc/sys/configure.in	2010-02-24 14:59:55.000000000 -0600
-+++ newlib-1.19.0/newlib/libc/sys/configure.in	2011-04-24 20:37:33.000000000 -0500
+diff -rupN _source/newlib/libc/sys/configure.in newlib-1.19.0/newlib/libc/sys/configure.in
+--- _source/newlib/libc/sys/configure.in	2010-02-24 20:59:55.000000000 +0000
++++ newlib-1.19.0/newlib/libc/sys/configure.in	2015-07-01 07:12:59.000000000 +0000
 @@ -45,6 +45,7 @@ if test -n "${sys_dir}"; then
  	sysvnecv70) AC_CONFIG_SUBDIRS(sysvnecv70) ;;
  	tic80) AC_CONFIG_SUBDIRS(tic80) ;;

--- a/toolchain/patches/newlib-1.19.0/00000-base.patch
+++ b/toolchain/patches/newlib-1.19.0/00000-base.patch
@@ -1,6 +1,6 @@
-diff -rupN _source/config.sub newlib-1.19.0/config.sub
---- _source/config.sub	2010-06-01 17:53:40.000000000 +0000
-+++ newlib-1.19.0/config.sub	2015-07-01 07:12:59.000000000 +0000
+diff -rupN _source/newlib-1.19.0/config.sub newlib-1.19.0/config.sub
+--- _source/newlib-1.19.0/config.sub	2010-06-01 12:53:40.000000000 -0500
++++ newlib-1.19.0/config.sub	2011-04-24 20:37:12.000000000 -0500
 @@ -1298,6 +1298,7 @@ case $os in
  	      | -sym* | -kopensolaris* \
  	      | -amigaos* | -amigados* | -msdos* | -newsos* | -unicos* | -aof* \
@@ -9,9 +9,9 @@ diff -rupN _source/config.sub newlib-1.19.0/config.sub
  	      | -nindy* | -vxsim* | -vxworks* | -ebmon* | -hms* | -mvs* \
  	      | -clix* | -riscos* | -uniplus* | -iris* | -rtu* | -xenix* \
  	      | -hiux* | -386bsd* | -knetbsd* | -mirbsd* | -netbsd* \
-diff -rupN _source/newlib/configure.host newlib-1.19.0/newlib/configure.host
---- _source/newlib/configure.host	2010-12-02 19:30:46.000000000 +0000
-+++ newlib-1.19.0/newlib/configure.host	2015-07-01 07:12:59.000000000 +0000
+diff -rupN _source/newlib-1.19.0/newlib/configure.host newlib-1.19.0/newlib/configure.host
+--- _source/newlib-1.19.0/newlib/configure.host	2010-12-02 13:30:46.000000000 -0600
++++ newlib-1.19.0/newlib/configure.host	2011-04-24 20:38:10.000000000 -0500
 @@ -418,6 +418,9 @@ case "${host}" in
    h8500-*-elf*)
  	sys_dir=h8500hms
@@ -20,8 +20,8 @@ diff -rupN _source/newlib/configure.host newlib-1.19.0/newlib/configure.host
 +	sys_dir=toaru
 +	;;
    i[34567]86-*-rdos*)
- 	sys_dir=rdos
- 	newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
+  sys_dir=rdos
+  newlib_cflags="${newlib_cflags} -DMISSING_SYSCALL_NAMES"
 @@ -543,6 +546,9 @@ esac
  # THIS TABLE IS ALPHA SORTED.  KEEP IT THAT WAY.
  
@@ -30,11 +30,11 @@ diff -rupN _source/newlib/configure.host newlib-1.19.0/newlib/configure.host
 +	newlib_cflags="${newlib_cflags} -fPIC -DSIGNAL_PROVIDED -DMISSING_SYSCALL_NAMES -DMALLOC_PROVIDED"
 +	;;
    *-*-cygwin*)
- 	test -z "$cygwin_srcdir" && cygwin_srcdir=`cd ${srcdir}/../winsup/cygwin; pwd`
- 	export cygwin_srcdir
-diff -rupN _source/newlib/libc/include/sys/stat.h newlib-1.19.0/newlib/libc/include/sys/stat.h
---- _source/newlib/libc/include/sys/stat.h	2010-08-06 18:26:21.000000000 +0000
-+++ newlib-1.19.0/newlib/libc/include/sys/stat.h	2015-07-01 07:12:59.000000000 +0000
+  test -z "$cygwin_srcdir" && cygwin_srcdir=`cd ${srcdir}/../winsup/cygwin; pwd`
+  export cygwin_srcdir
+diff -rupN _source/newlib-1.19.0/newlib/libc/include/sys/stat.h newlib-1.19.0/newlib/libc/include/sys/stat.h
+--- _source/newlib-1.19.0/newlib/libc/include/sys/stat.h	2010-08-06 13:26:21.000000000 -0500
++++ newlib-1.19.0/newlib/libc/include/sys/stat.h	2012-04-23 16:00:11.000000000 -0500
 @@ -150,8 +150,8 @@ int	_EXFUN(mkfifo,( const char *__path,
  int	_EXFUN(stat,( const char *__path, struct stat *__sbuf ));
  mode_t	_EXFUN(umask,( mode_t __mask ));
@@ -45,22 +45,9 @@ diff -rupN _source/newlib/libc/include/sys/stat.h newlib-1.19.0/newlib/libc/incl
  int	_EXFUN(mknod,( const char *__path, mode_t __mode, dev_t __dev ));
  #endif
  
-diff -rupN _source/newlib/libc/include/sys/unistd.h newlib-1.19.0/newlib/libc/include/sys/unistd.h
---- _source/newlib/libc/include/sys/unistd.h	2010-10-08 15:28:49.000000000 +0000
-+++ newlib-1.19.0/newlib/libc/include/sys/unistd.h	2015-07-01 07:16:16.000000000 +0000
-@@ -53,9 +53,7 @@ int     _EXFUN(execvp, (const char *__fi
- int     _EXFUN(execvpe, (const char *__file, char * const __argv[], char * const __envp[] ));
- int	_EXFUN(faccessat, (int __dirfd, const char *__path, int __mode, int __flags));
- #endif
--#if defined(__CYGWIN__) || defined(__rtems__) || defined(__SPU__)
- int     _EXFUN(fchdir, (int __fildes));
--#endif
- int     _EXFUN(fchmod, (int __fildes, mode_t __mode ));
- #if !defined(__INSIDE_CYGWIN__)
- int     _EXFUN(fchown, (int __fildes, uid_t __owner, gid_t __group ));
-diff -rupN _source/newlib/libc/include/sys/utime.h newlib-1.19.0/newlib/libc/include/sys/utime.h
---- _source/newlib/libc/include/sys/utime.h	2000-02-17 19:39:46.000000000 +0000
-+++ newlib-1.19.0/newlib/libc/include/sys/utime.h	2015-07-01 07:12:59.000000000 +0000
+diff -rupN _source/newlib-1.19.0/newlib/libc/include/sys/utime.h newlib-1.19.0/newlib/libc/include/sys/utime.h
+--- _source/newlib-1.19.0/newlib/libc/include/sys/utime.h	2000-02-17 13:39:46.000000000 -0600
++++ newlib-1.19.0/newlib/libc/include/sys/utime.h	2012-04-23 16:01:17.000000000 -0500
 @@ -15,6 +15,8 @@ struct utimbuf
    time_t modtime; 
  };
@@ -70,9 +57,9 @@ diff -rupN _source/newlib/libc/include/sys/utime.h newlib-1.19.0/newlib/libc/inc
  #ifdef __cplusplus
  };
  #endif
-diff -rupN _source/newlib/libc/stdio/fseek.c newlib-1.19.0/newlib/libc/stdio/fseek.c
---- _source/newlib/libc/stdio/fseek.c	2009-12-17 19:43:43.000000000 +0000
-+++ newlib-1.19.0/newlib/libc/stdio/fseek.c	2015-07-01 07:12:59.000000000 +0000
+diff -rupN _source/newlib-1.19.0/newlib/libc/stdio/fseek.c newlib-1.19.0/newlib/libc/stdio/fseek.c
+--- _source/newlib-1.19.0/newlib/libc/stdio/fseek.c	2009-12-17 13:43:43.000000000 -0600
++++ newlib-1.19.0/newlib/libc/stdio/fseek.c	2011-04-29 19:33:10.000000000 -0500
 @@ -160,210 +160,6 @@ _DEFUN(_fseek_r, (ptr, fp, offset, whenc
        return EOF;
      }
@@ -284,9 +271,9 @@ diff -rupN _source/newlib/libc/stdio/fseek.c newlib-1.19.0/newlib/libc/stdio/fse
  dumb:
    if (_fflush_r (ptr, fp)
        || seekfn (ptr, fp->_cookie, offset, whence) == POS_ERR)
-diff -rupN _source/newlib/libc/stdlib/mallocr.c newlib-1.19.0/newlib/libc/stdlib/mallocr.c
---- _source/newlib/libc/stdlib/mallocr.c	2010-05-31 19:15:41.000000000 +0000
-+++ newlib-1.19.0/newlib/libc/stdlib/mallocr.c	2015-07-01 07:12:59.000000000 +0000
+diff -rupN _source/newlib-1.19.0/newlib/libc/stdlib/mallocr.c newlib-1.19.0/newlib/libc/stdlib/mallocr.c
+--- _source/newlib-1.19.0/newlib/libc/stdlib/mallocr.c	2010-05-31 14:15:41.000000000 -0500
++++ newlib-1.19.0/newlib/libc/stdlib/mallocr.c	2011-04-30 21:28:46.000000000 -0500
 @@ -609,8 +609,11 @@ do {
    operating system immediately after a free().
  */
@@ -300,9 +287,9 @@ diff -rupN _source/newlib/libc/stdlib/mallocr.c newlib-1.19.0/newlib/libc/stdlib
  #endif
  
  /*
-diff -rupN _source/newlib/libc/sys/configure newlib-1.19.0/newlib/libc/sys/configure
---- _source/newlib/libc/sys/configure	2010-12-16 21:59:03.000000000 +0000
-+++ newlib-1.19.0/newlib/libc/sys/configure	2015-07-01 07:12:59.000000000 +0000
+diff -rupN _source/newlib-1.19.0/newlib/libc/sys/configure newlib-1.19.0/newlib/libc/sys/configure
+--- _source/newlib-1.19.0/newlib/libc/sys/configure	2010-12-16 15:59:03.000000000 -0600
++++ newlib-1.19.0/newlib/libc/sys/configure	2011-04-24 20:39:58.000000000 -0500
 @@ -798,6 +798,7 @@ sysvi386
  sysvnecv70
  tic80
@@ -311,7 +298,7 @@ diff -rupN _source/newlib/libc/sys/configure newlib-1.19.0/newlib/libc/sys/confi
  z8ksim'
  
  # Initialize some variables set by options.
-@@ -11820,6 +11821,8 @@ subdirs="$subdirs a29khif"
+@@ -11820,6 +11827,8 @@ subdirs="$subdirs a29khif"
   ;;
  	w65) subdirs="$subdirs w65"
   ;;
@@ -320,9 +307,9 @@ diff -rupN _source/newlib/libc/sys/configure newlib-1.19.0/newlib/libc/sys/confi
  	z8ksim) subdirs="$subdirs z8ksim"
   ;;
    esac;
-diff -rupN _source/newlib/libc/sys/configure.in newlib-1.19.0/newlib/libc/sys/configure.in
---- _source/newlib/libc/sys/configure.in	2010-02-24 20:59:55.000000000 +0000
-+++ newlib-1.19.0/newlib/libc/sys/configure.in	2015-07-01 07:12:59.000000000 +0000
+diff -rupN _source/newlib-1.19.0/newlib/libc/sys/configure.in newlib-1.19.0/newlib/libc/sys/configure.in
+--- _source/newlib-1.19.0/newlib/libc/sys/configure.in	2010-02-24 14:59:55.000000000 -0600
++++ newlib-1.19.0/newlib/libc/sys/configure.in	2011-04-24 20:37:33.000000000 -0500
 @@ -45,6 +45,7 @@ if test -n "${sys_dir}"; then
  	sysvnecv70) AC_CONFIG_SUBDIRS(sysvnecv70) ;;
  	tic80) AC_CONFIG_SUBDIRS(tic80) ;;

--- a/toolchain/patches/newlib-1.19.0/00001-declare-fchdir.patch
+++ b/toolchain/patches/newlib-1.19.0/00001-declare-fchdir.patch
@@ -1,0 +1,13 @@
+diff -rupN _source/newlib/libc/include/sys/unistd.h newlib-1.19.0/newlib/libc/include/sys/unistd.h
+--- _source/newlib/libc/include/sys/unistd.h	2010-10-08 15:28:49.000000000 +0000
++++ newlib-1.19.0/newlib/libc/include/sys/unistd.h	2015-07-01 07:16:16.000000000 +0000
+@@ -53,9 +53,7 @@ int     _EXFUN(execvp, (const char *__fi
+ int     _EXFUN(execvpe, (const char *__file, char * const __argv[], char * const __envp[] ));
+ int	_EXFUN(faccessat, (int __dirfd, const char *__path, int __mode, int __flags));
+ #endif
+-#if defined(__CYGWIN__) || defined(__rtems__) || defined(__SPU__)
+ int     _EXFUN(fchdir, (int __fildes));
+-#endif
+ int     _EXFUN(fchmod, (int __fildes, mode_t __mode ));
+ #if !defined(__INSIDE_CYGWIN__)
+ int     _EXFUN(fchown, (int __fildes, uid_t __owner, gid_t __group ));

--- a/toolchain/patches/newlib/include/syscall_nums.h
+++ b/toolchain/patches/newlib/include/syscall_nums.h
@@ -45,3 +45,4 @@
 #define SYS_SYMLINK 56
 #define SYS_READLINK 57
 #define SYS_LSTAT 58
+#define SYS_FCHDIR 59

--- a/toolchain/patches/newlib/toaru/syscalls.c
+++ b/toolchain/patches/newlib/toaru/syscalls.c
@@ -92,6 +92,7 @@ DEFN_SYSCALL5(mount, SYS_MOUNT, char *, char *, char *, unsigned long, void *);
 DEFN_SYSCALL2(symlink, SYS_SYMLINK, char *, char *);
 DEFN_SYSCALL3(readlink, SYS_READLINK, char *, char *, int);
 DEFN_SYSCALL2(lstat, SYS_LSTAT, char *, void *);
+DEFN_SYSCALL1(fchdir, SYS_FCHDIR, int);
 
 static int toaru_debug_stubs_enabled(void) {
 	static int checked = 0;
@@ -711,6 +712,17 @@ int symlink(char * target, char * name) {
 
 int readlink(char * name, char * buf, size_t len) {
 	int r = syscall_readlink(name, buf, len);
+
+	if (r < 0) {
+		errno = -r;
+		return -1;
+	}
+
+	return r;
+}
+
+int fchdir(int filedes) {
+	int r = syscall_fchdir(filedes);
 
 	if (r < 0) {
 		errno = -r;

--- a/toolchain/util.sh
+++ b/toolchain/util.sh
@@ -24,6 +24,14 @@ function patc () {
     $BEG "patch" "Patching $1..."
     pushd "$2" > /dev/null
     patch -p1 < $DIR/patches/$2.patch > /dev/null
+    if [ -d "../../patches/$2" ]; then
+        for patchfile in $DIR/patches/$2/*.patch; do
+            $INFO "patch" "Applying $(echo $patchfile | rev | cut -d/ -f1 | rev)"
+            patch -p1 < $patchfile > /dev/null
+        done
+    else
+        patch -p1 < $DIR/patches/$2.patch > /dev/null
+    fi
     popd > /dev/null
     $END "patch" "$1"
 }

--- a/userspace/tests/test-fchdir.c
+++ b/userspace/tests/test-fchdir.c
@@ -1,0 +1,53 @@
+/* vim: tabstop=4 shiftwidth=4 noexpandtab
+ * This file is part of ToaruOS and is released under the terms
+ * of the NCSA / University of Illinois License - see LICENSE.md
+ * Copyright (C) 2015 Mike Gerow
+ */
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "lib/testing.h"
+
+int main(int argc, char * argv[]) {
+	INFO("Starting fchdir test");
+	int failed = 0;
+	int fd = open("/home", 0);
+	if (fd == -1) {
+		perror("open(\"/home\", 0)");
+		FAIL("open failed for directory");
+		failed = 1;
+	}
+	int rv = fchdir(fd);
+	if (rv == -1) {
+		perror("fchdir");
+		FAIL("fchdir failed");
+		failed = 1;
+	}
+	rv = close(fd);
+	if (rv == -1) {
+		perror("close");
+		FAIL("close failed");
+		failed = 1;
+	}
+	char buf[4096];
+	if (getcwd(buf, sizeof(buf)) == NULL) {
+		perror("getcwd");
+		FAIL("getcwd failed");
+		failed = 1;
+	}
+	if (strcmp(buf, "/home") != 0) {
+		FAIL("cwd does not match -- expected \"/home\", got \"%s\"", buf);
+		failed = 1;
+	}
+
+	if (failed) {
+		FAIL("test-fchdir failed");
+		exit(EXIT_FAILURE);
+	}
+
+	INFO("test-fchdir passed");
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
Working on trying to port libarchive to toaruos to do some kind of packaging stuff, it seemed easier to just implement fchdir than try to patch it out. The one thing I'm wary about is that this increases the size of the fs node struct by 4k in order to store the path it was opened under. It seems like it might be useful to keep track of the path a file was opened as for other things, but this is the only one so far.

Also, diffs of diffs are fun to read.
