### PR TITLE
Fix building of toolchain on Fedora systems

### DIFF
--- a/toolchain/toolchain-build.sh
+++ b/toolchain/toolchain-build.sh
@@ -26,9 +26,9 @@ if [[ "$INSTALL_PACKAGES" == "true" ]] ; then
     if [ -f /etc/debian_version ]; then
         sudo apt-get install yasm genext2fs build-essential wget libmpfr-dev libmpc-dev libgmp3-dev qemu autoconf automake texinfo pkg-config git ctags gperf
     elif [ -f /etc/fedora-release ]; then
-        sudo yum groupinstall 'Development Tools'
-        sudo yum groupinstall 'Development Libraries'
-        sudo yum install yasm mpfr-devel libmpc-devel gmp-devel
+        sudo dnf groupinstall 'Development Tools'
+        sudo dnf groupinstall 'Development Libraries'
+        sudo dnf install yasm mpfr-devel libmpc-devel gmp-devel gperf
         echo "Warning: Fedora is unsupported in this script. Be careful!"
         echo "For best results, follow the steps in the script manually."
         echo "(Script will continue in 5 seconds)"


### PR DESCRIPTION
Updated the toolchain build script to install `gperf` on Fedora systems, as the build fails without it.
Also changed `yum` to `dnf` as the former is deprecated and redirects to `dnf` on newer Fedora systems.