### PR TITLE
Replace magic numbers with syscall constants in libc/unistd

### DIFF
--- a/libc/unistd/chdir.c
+++ b/libc/unistd/chdir.c
@@ -1,8 +1,9 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 #include <errno.h>
 
-DEFN_SYSCALL1(chdir, 28, char *);
+DEFN_SYSCALL1(chdir, SYS_CHDIR, char *);
 
 int chdir(const char *path) {
 	__sets_errno(syscall_chdir((char*)path));

--- a/libc/unistd/chmod.c
+++ b/libc/unistd/chmod.c
@@ -1,8 +1,9 @@
 #include <errno.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 #include <sys/stat.h>
 
-DEFN_SYSCALL2(chmod, 50, char *, int);
+DEFN_SYSCALL2(chmod, SYS_CHMOD, char *, int);
 
 int chmod(const char *path, mode_t mode) {
 	__sets_errno(syscall_chmod((char *)path, mode));

--- a/libc/unistd/close.c
+++ b/libc/unistd/close.c
@@ -1,7 +1,8 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL1(close, 5, int);
+DEFN_SYSCALL1(close, SYS_CLOSE, int);
 
 int close(int file) {
 	return syscall_close(file);

--- a/libc/unistd/dup2.c
+++ b/libc/unistd/dup2.c
@@ -1,7 +1,8 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL2(dup2, 22, int, int);
+DEFN_SYSCALL2(dup2, SYS_DUP2, int, int);
 
 int dup2(int oldfd, int newfd) {
 	return syscall_dup2(oldfd, newfd);

--- a/libc/unistd/fork.c
+++ b/libc/unistd/fork.c
@@ -1,7 +1,8 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL0(fork, 8);
+DEFN_SYSCALL0(fork, SYS_FORK);
 
 pid_t fork(void) {
 	return syscall_fork();

--- a/libc/unistd/getcwd.c
+++ b/libc/unistd/getcwd.c
@@ -1,8 +1,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL2(getcwd, 29, char *, size_t);
+DEFN_SYSCALL2(getcwd, SYS_GETCWD, char *, size_t);
 
 char *getcwd(char *buf, size_t size) {
 	if (!buf) buf = malloc(size);

--- a/libc/unistd/lseek.c
+++ b/libc/unistd/lseek.c
@@ -1,7 +1,8 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL3(lseek, 14, int, int, int);
+DEFN_SYSCALL3(lseek, SYS_SEEK, int, int, int);
 
 off_t lseek(int file, off_t ptr, int dir) {
 	return syscall_lseek(file,ptr,dir);

--- a/libc/unistd/open.c
+++ b/libc/unistd/open.c
@@ -4,8 +4,9 @@
 #include <errno.h>
 
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL3(open,  2, const char *, int, int);
+DEFN_SYSCALL3(open, SYS_OPEN, const char *, int, int);
 
 int open(const char *name, int flags, ...) {
 	va_list argp;

--- a/libc/unistd/pipe.c
+++ b/libc/unistd/pipe.c
@@ -1,8 +1,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL1(pipe, 54, int *);
+DEFN_SYSCALL1(pipe, SYS_PIPE, int *);
 
 int pipe(int fildes[2]) {
 	__sets_errno(syscall_pipe((int *)fildes));

--- a/libc/unistd/read.c
+++ b/libc/unistd/read.c
@@ -1,7 +1,8 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL3(read,  3, int, char *, int);
+DEFN_SYSCALL3(read, SYS_READ, int, char *, int);
 
 int read(int file, void *ptr, size_t len) {
 	return syscall_read(file,ptr,len);

--- a/libc/unistd/setuid.c
+++ b/libc/unistd/setuid.c
@@ -1,7 +1,8 @@
 #include <syscall.h>
+#include <syscall_nums.h>
 #include <sys/types.h>
 
-DEFN_SYSCALL1(setuid, 24, unsigned int);
+DEFN_SYSCALL1(setuid, SYS_SETUID, unsigned int);
 
 int setuid(uid_t uid) {
 	return syscall_setuid(uid);

--- a/libc/unistd/sleep.c
+++ b/libc/unistd/sleep.c
@@ -1,4 +1,5 @@
 #include <syscall.h>
+#include <syscall_nums.h>
 
 unsigned int sleep(unsigned int seconds) {
 	syscall_nanosleep(seconds, 0);

--- a/libc/unistd/usleep.c
+++ b/libc/unistd/usleep.c
@@ -1,7 +1,8 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL2(nanosleep,  46, unsigned long, unsigned long);
+DEFN_SYSCALL2(nanosleep, SYS_SLEEP, unsigned long, unsigned long);
 
 int usleep(useconds_t usec) {
 	syscall_nanosleep((usec / 10000) / 1000, (usec / 10000) % 1000);

--- a/libc/unistd/write.c
+++ b/libc/unistd/write.c
@@ -1,7 +1,8 @@
 #include <unistd.h>
 #include <syscall.h>
+#include <syscall_nums.h>
 
-DEFN_SYSCALL3(write, 4, int, char *, int);
+DEFN_SYSCALL3(write, SYS_WRITE, int, char *, int);
 
 ssize_t write(int file, const void *ptr, size_t len) {
 	return syscall_write(file,(char *)ptr,len);


### PR DESCRIPTION
## Summary

Many of the system call wrappers in `unistd` already use the constants defined in the `<syscall_nums.h>` header file. This patch makes that consistent across all of the functions in `unistd`.

## Testing:

Double-checked that each named constant's value was the same as the magic number before replacing it in source code.

Clean compile and boot. Played around with user commands in `/bin` which exercise various system calls. System's still stable.