### PR TITLE
Add Group ID (gid) functionality to processes

### DIFF
--- a/apps/chgrp.c
+++ b/apps/chgrp.c
@@ -1,0 +1,26 @@
+/* vim: tabstop=4 shiftwidth=4 noexpandtab
+ * This file is part of ToaruOS and is released under the terms
+ * of the NCSA / University of Illinois License - see LICENSE.md
+ * Copyright (C) 2018 K. Lange
+ *
+ * chgrp
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+
+int main(int argc, char * argv[]) {
+	if (argc != 3) {
+		fprintf(stderr, "usage: chgrp GID FILE\n");
+		return 1;
+	}
+
+	int gid = atoi(argv[1]);
+
+	if (chown(argv[2], getuid(), gid)) {
+		fprintf(stderr, "chgrp: %s: %s\n", argv[2], strerror(errno));
+		return 1;
+	}
+	return 0;
+}

--- a/apps/chown.c
+++ b/apps/chown.c
@@ -18,7 +18,7 @@ int main(int argc, char * argv[]) {
 
 	int uid = atoi(argv[1]);
 
-	if (chown(argv[2], uid, uid)) {
+	if (chown(argv[2], uid, getgid())) {
 		fprintf(stderr, "chown: %s: %s\n", argv[2], strerror(errno));
 		return 1;
 	}

--- a/base/usr/include/kernel/process.h
+++ b/base/usr/include/kernel/process.h
@@ -12,6 +12,7 @@
 
 typedef signed int    pid_t;
 typedef unsigned int  user_t;
+typedef unsigned int  group_t;
 typedef unsigned int  status_t;
 
 #define USER_ROOT_UID (user_t)0
@@ -75,6 +76,8 @@ typedef struct process {
 	char *        description;       /* Process description */
 	user_t        user;              /* Effective user */
 	user_t        real_user;         /* Real user ID */
+	group_t       group_id;          /* Group ID */
+	group_t       real_group_id;     /* Real group ID */
 	int           mask;              /* Umask */
 
 	char **       cmdline;

--- a/base/usr/include/syscall.h
+++ b/base/usr/include/syscall.h
@@ -121,6 +121,9 @@ DECL_SYSCALL0(setsid);
 DECL_SYSCALL2(setpgid,int,int);
 DECL_SYSCALL1(getpgid,int);
 DECL_SYSCALL0(geteuid);
+DECL_SYSCALL0(getgid);
+DECL_SYSCALL0(getegid);
+DECL_SYSCALL1(setgid, unsigned int);
 
 _End_C_Header
 

--- a/base/usr/include/syscall_nums.h
+++ b/base/usr/include/syscall_nums.h
@@ -54,3 +54,6 @@
 #define SYS_SETSID 62
 #define SYS_SETPGID 63
 #define SYS_GETPGID 64
+#define SYS_GETGID 65
+#define SYS_SETGID 66
+#define SYS_GETEGID 67

--- a/base/usr/include/unistd.h
+++ b/base/usr/include/unistd.h
@@ -25,6 +25,7 @@ extern int execve(const char *name, char * const argv[], char * const envp[]);
 extern void _exit(int status);
 
 extern int setuid(uid_t uid);
+extern int setgid(gid_t gid);
 
 extern uid_t getuid(void);
 extern uid_t geteuid(void);

--- a/kernel/fs/vfs.c
+++ b/kernel/fs/vfs.c
@@ -36,12 +36,13 @@ int has_permission(fs_node_t * node, int permission_bit) {
 	uint32_t permissions = node->mask;
 
 	uint8_t user_perm  = (permissions >> 6) & 07;
-	//uint8_t group_perm = (permissions >> 3) & 07;
+	uint8_t group_perm = (permissions >> 3) & 07;
 	uint8_t other_perm = (permissions) & 07;
 
 	if (current_process->user == node->uid) {
 		return (permission_bit & user_perm);
-		/* TODO group permissions? */
+	} else if (current_process->group_id == node->gid) {
+		return (permission_bit & group_perm);
 	} else {
 		return (permission_bit & other_perm);
 	}

--- a/kernel/sys/process.c
+++ b/kernel/sys/process.c
@@ -272,6 +272,8 @@ process_t * spawn_init(void) {
 	init->cmdline = NULL;
 	init->user    = 0;       /* UID 0 */
 	init->real_user = 0;
+	init->group_id  = 0;     /* GID 0 */
+	init->real_group_id = 0;
 	init->mask    = 022;     /* umask */
 	init->status  = 0;       /* Run status */
 	init->fds = malloc(sizeof(fd_table_t));
@@ -391,6 +393,8 @@ process_t * spawn_process(volatile process_t * parent, int reuse_fds) {
 	/* Copy permissions */
 	proc->user  = parent->user;
 	proc->real_user = parent->real_user;
+	proc->group_id = parent->group_id;
+	proc->real_group_id = parent->real_group_id;
 	proc->mask = parent->mask;
 
 	/* Until specified otherwise */

--- a/kernel/sys/syscall.c
+++ b/kernel/sys/syscall.c
@@ -450,6 +450,20 @@ static int sys_geteuid(void) {
 	return current_process->user;
 }
 
+static int sys_getgid(void) {
+	return current_process->real_group_id;
+}
+
+static int sys_getegid(void) {
+	return current_process->group_id;
+}
+
+static int sys_setgid(group_t new_gid) {
+	/* TODO do we need similar conditional from sys_setuid()? */
+	current_process->group_id = new_gid;
+	return 0;
+}
+
 static int sys_setuid(user_t new_uid) {
 	if (current_process->user == USER_ROOT_UID) {
 		current_process->user = new_uid;
@@ -1102,6 +1116,9 @@ static int (*syscalls[])() = {
 	[SYS_SETSID]       = sys_setsid,
 	[SYS_SETPGID]      = sys_setpgid,
 	[SYS_GETPGID]      = sys_getpgid,
+	[SYS_GETGID]       = sys_getgid,
+	[SYS_GETEGID]      = sys_getegid,
+	[SYS_SETGID]       = sys_setgid,
 };
 
 uint32_t num_syscalls = sizeof(syscalls) / sizeof(*syscalls);

--- a/libc/unistd/getegid.c
+++ b/libc/unistd/getegid.c
@@ -1,6 +1,10 @@
 #include <unistd.h>
+#include <syscall.h>
+#include <syscall_nums.h>
 
-int getegid() {
-	return getgid();
+DEFN_SYSCALL0(getegid, SYS_GETEGID);
+
+gid_t getegid() {
+	return syscall_getegid();
 }
 

--- a/libc/unistd/getgid.c
+++ b/libc/unistd/getgid.c
@@ -1,5 +1,9 @@
 #include <unistd.h>
+#include <syscall.h>
+#include <syscall_nums.h>
 
-int getgid() {
-	return getuid();
+DEFN_SYSCALL0(getgid, SYS_GETGID);
+
+gid_t getgid(void) {
+	return syscall_getgid();
 }

--- a/libc/unistd/setgid.c
+++ b/libc/unistd/setgid.c
@@ -1,4 +1,5 @@
 #include <syscall.h>
+#include <syscall_nums.h>
 #include <sys/types.h>
 
 DEFN_SYSCALL1(setgid, SYS_SETGID, unsigned int);

--- a/libc/unistd/setgid.c
+++ b/libc/unistd/setgid.c
@@ -1,0 +1,8 @@
+#include <syscall.h>
+#include <sys/types.h>
+
+DEFN_SYSCALL1(setgid, SYS_SETGID, unsigned int);
+
+int setgid(gid_t gid) {
+	return syscall_setgid(gid);
+}

--- a/modules/procfs.c
+++ b/modules/procfs.c
@@ -166,6 +166,7 @@ static uint32_t proc_status_func(fs_node_t *node, uint64_t offset, uint32_t size
 			"Pgid:\t%d\n" /* progress group id */
 			"Sid:\t%d\n" /* session id */
 			"Uid:\t%d\n"
+			"Gid:\t%d\n"
 			"Ueip:\t0x%x\n"
 			"SCid:\t%d\n"
 			"SC0:\t0x%x\n"
@@ -187,6 +188,7 @@ static uint32_t proc_status_func(fs_node_t *node, uint64_t offset, uint32_t size
 			proc->job,
 			proc->session,
 			proc->user,
+			proc->group_id,
 			proc->syscall_registers ? proc->syscall_registers->eip : 0,
 			proc->syscall_registers ? proc->syscall_registers->eax : 0,
 			proc->syscall_registers ? proc->syscall_registers->ebx : 0,


### PR DESCRIPTION
This PR adds the Group ID feature to processes on the system. This addition enables checking group permissions through the [`has_permissions()`](https://github.com/klange/toaruos/blob/master/kernel/fs/vfs.c#L44) function.

In addition to adding the group ID field to the process structure, the following changes are included with this PR:

* `spawn_init()` has been updated to initialize the GID. Similarly, `spawn_process()` has been updated to inherit the GID from the parent.

* System calls for setting and getting the process GID have been implemented.

* The `chown` command has been updated to appropriately submit the current `gid` instead of the process's `uid` in its place.

* The `chgrp` command has been added. It is basically identical to the `chown` command implementation except it operates on changing the GID.

* The `procfs` module's `status` function has been updated to show the process GID.

* The `has_permissions()` function has been updated to check the GID.

**Testing**

I didn't see a folder for test programs so I wasn't sure if it was appropriate to even add one in this PR.

I tested this manually with `make headless` and a small toy program that would set the process GID using the `getgid()` and `setgid()` system calls. I ran this as a background process and then checked `/proc/pid/status` to verify the new GID was there.

**Remarks**

To the best of my knowledge I believe this PR is complete. I'm still getting familiar with the code base so any feedback on whether this change is incomplete, unnecessary, unwanted, etc, is greatly appreciated.