### PR TITLE
int errno = 0; int errno; has been changed to.

### DIFF
--- a/libc/errno/errorno.c
+++ b/libc/errno/errorno.c
@@ -1,3 +1,3 @@
 #include <errno.h>
 
-int errno = 0;
+int errno;


### PR DESCRIPTION
Every integer (int) value created in the C programming language is 0 by default, so "int errno = 0;" This code is unnecessary, instead int errno; I changed it to.