### PR TITLE
use M_PI/M_E constants from math.h

### DIFF
--- a/libc/math/math.c
+++ b/libc/math/math.c
@@ -11,7 +11,7 @@ extern char * _argv_0;
 #endif
 
 double exp(double x) {
-	return pow(2.71828182846, x);
+	return pow(M_E, x);
 }
 
 int abs(int j) {
@@ -398,10 +398,10 @@ static double bad_sine_table[] = {
 double sin(double x) {
 	MATH;
 	if (x < 0.0) {
-		x += 3.141592654 * 2.0 * 100.0;
+		x += M_PI * 2.0 * 100.0;
 	}
-	int i = x * 360.0 / (3.141592654 * 2.0);
-	double z = x * 360.0 / (3.141592654 * 2.0);
+	int i = x * 360.0 / (M_PI * 2.0);
+	double z = x * 360.0 / (M_PI * 2.0);
 	z -= i;
 
 	i = i % 360;
@@ -415,7 +415,7 @@ double sin(double x) {
 }
 
 double cos(double x) {
-	return sin(x + 3.141592654 / 2.0);
+	return sin(x + M_PI / 2.0);
 }
 
 double atan(double x) {


### PR DESCRIPTION
* Don't duplicate values for pi and e which are already available as constants
* Existing definitions of M_PI and M_E also had greater precision than the literals being used
* Compile-tested with `gcc -c math.c` on ToaruOS/x86_64 only