### PR TITLE
stty: correct prefix match for baud rate

### DIFF
--- a/apps/stty.c
+++ b/apps/stty.c
@@ -355,7 +355,7 @@ int main(int argc, char * argv[]) {
 			continue;
 		}
 
-		if (*argv[i] >= '0' && *argv[i] < '9') {
+		if (*argv[i] >= '0' && *argv[i] <= '9') {
 			if (set_baud_rate(&t, argv[i])) {
 				i++;
 				continue;


### PR DESCRIPTION
At least one baud rate starts with 9, but the digit match was treating 9xxx as invalid argument.
