### PR TITLE
fix: prevent symlink TOCTOU race in sys_open with O_CREAT

### DIFF
--- a/kernel/sys/syscall.c
+++ b/kernel/sys/syscall.c
@@ -402,7 +402,7 @@ long sys_open(const char * file, long flags, long mode) {
 		/* TODO check directory permissions */
 		int result = create_file_fs((char *)file, mode);
 		if (!result) {
-			node = kopen((char *)file, flags);
+			node = kopen((char *)file, flags | O_NOFOLLOW);
 		} else {
 			return result;
 		}


### PR DESCRIPTION
Fixes #312.

The second kopen() in the O_CREAT path now passes O_NOFOLLOW. If the newly created file was replaced with a symlink between create_file_fs and kopen, kopen returns NULL and the syscall fails with -ENOENT instead of following the symlink.

One-line change, no VFS interface modifications. O_NOFOLLOW only affects the final path component so parent symlinks still resolve normally.

Made with [Cursor](https://cursor.com)