### PR TITLE
Missing free() in sock_raw_recv() error path

### DIFF
--- a/kernel/net/socket.c
+++ b/kernel/net/socket.c
@@ -146,7 +146,10 @@ static long sock_raw_recv(sock_t * sock, struct msghdr * msg, int flags) {
 	char * data = net_sock_get(sock);
 	if (!data) return -EINTR;
 	size_t packet_size = *(size_t*)data;
-	if (msg->msg_iov[0].iov_len < packet_size) return -EINVAL;
+	if (msg->msg_iov[0].iov_len < packet_size) {
+		free(data);
+		return -EINVAL;
+	}
 	memcpy(msg->msg_iov[0].iov_base, data + sizeof(size_t), packet_size);
 	free(data);
 	return 4096;


### PR DESCRIPTION
* 5th return statement in sock_raw_recv() happens after "data" is verified as non-NULL
* Final (success) return frees data, so do the same here
* Builds successfully on ToaruOS/x86_64