### PR TITLE
cmp: string.h for strerror()

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <string.h>
 
 static int usage(char * argv[]) {
 	fprintf(stderr, "usage: %s [-l | -s] file1 file2\n", argv[0]);


### PR DESCRIPTION
Previously cmp.c fails to build on Linux. This is not a showstopper, but possibly the strerror() declaration should not implicitly happen in the other libc headers, to conform to standard [1].
```
clang -O2 -Wall   -c -o cmp.o cmp.c
cmp.c:49:52: error: call to undeclared library function 'strerror' with type 'char *(int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   49 |                 fprintf(stderr, "%s: %s: %s\n", argv[0], file_a, strerror(errno));
      |                                                                  ^
cmp.c:49:52: note: include the header <string.h> or explicitly provide a declaration for 'strerror'
1 error generated.
```

1. https://pubs.opengroup.org/onlinepubs/9799919799/functions/strerror.html