### PR TITLE
hexify: stdlib.h for atoi()

### DIFF
--- a/apps/hexify.c
+++ b/apps/hexify.c
@@ -9,6 +9,7 @@
  * Copyright (C) 2018 K. Lange
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
 #include <unistd.h>


### PR DESCRIPTION
Previously hexify.c fails to build on Linux. This doesn't affect the native build on ToaruOS. Possibly the atoi() declaration should not implicitly happen in the other libc headers, to conform to standard [1].
```
hexify.c:93:13: error: call to undeclared function 'atoi'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   93 |                                 width = atoi(optarg);
      |                                         ^
1 error generated.
```

1. https://pubs.opengroup.org/onlinepubs/9799919799/functions/atoi.html