### PR TITLE
nslookup: arpa/inet.h for inet_ntoa()

### DIFF
--- a/apps/nslookup.c
+++ b/apps/nslookup.c
@@ -14,6 +14,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <arpa/inet.h>
 
 int main(int argc, char * argv[]) {
 	if (argc < 2) return 1;


### PR DESCRIPTION
Previously nslookup.c fails to build on Linux. This doesn't affect the native build on ToaruOS. Possibly the inet_ntoa() declaration should not implicitly happen in the other libc headers, to conform to standard [1].
```
clang -O2 -Wall   -c -o nslookup.o nslookup.c
nslookup.c:28:16: error: call to undeclared function 'inet_ntoa'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   28 |         char * addr = inet_ntoa(*(struct in_addr*)host->h_addr_list[0]);
      |                       ^
nslookup.c:28:9: error: incompatible integer to pointer conversion initializing 'char *' with an expression of type 'int' [-Wint-conversion]
   28 |         char * addr = inet_ntoa(*(struct in_addr*)host->h_addr_list[0]);
      |                ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

1. https://pubs.opengroup.org/onlinepubs/9799919799/functions/inet_ntoa.html